### PR TITLE
add checker for >0 minimum length

### DIFF
--- a/lib/api_checker/check/json_check.ex
+++ b/lib/api_checker/check/json_check.ex
@@ -48,7 +48,7 @@ defmodule ApiChecker.Check.JsonCheck do
   iex> JsonCheck.expectation_exists?("not_empty")
   true
   """
-  def expectation_exists?(name) when is_list(name) when is_binary(name) do
+  def expectation_exists?(name) do
     case get_expectation_func(name) do
       {:ok, _} -> true
       _ -> false
@@ -74,6 +74,11 @@ defmodule ApiChecker.Check.JsonCheck do
   """
   def get_expectation_func("jsonapi"), do: {:ok, &Jsonapi.validate/1}
   def get_expectation_func("not_empty"), do: {:ok, &Array.validate_not_empty/1}
+
+  def get_expectation_func(%{"expectation" => "min_length", "min_length" => min_length})
+      when is_integer(min_length) and min_length > 0,
+      do: {:ok, &Array.validate_min_length(&1, min_length)}
+
   def get_expectation_func(_), do: {:error, :no_such_expectation}
 
   @doc """

--- a/lib/api_checker/check/json_check/array.ex
+++ b/lib/api_checker/check/json_check/array.ex
@@ -28,4 +28,32 @@ defmodule ApiChecker.Check.JsonCheck.Array do
   def validate_not_empty(_) do
     {:error, :invalid_array}
   end
+
+  @doc """
+  Returns {:ok, length: length} for lists that are at least the provided length
+  Returns {:error, {:array_too_small, length}} if the array is too small.
+  Returns {:error, :invalid_array} if the argument is not a list.
+
+  iex> Array.validate_min_length([1, 2], 2)
+  {:ok, length: 2}
+
+  iex> Array.validate_min_length([1], 2)
+  {:error, {:array_too_small, 1}}
+
+  iex> Array.validate_min_length(:ok, 1)
+  {:error, :invalid_array}
+  """
+  def validate_min_length(list, min_length) when is_list(list) do
+    list_length = length(list)
+
+    if list_length >= min_length do
+      {:ok, length: list_length}
+    else
+      {:error, {:array_too_small, list_length}}
+    end
+  end
+
+  def validate_min_length(_, _) do
+    {:error, :invalid_array}
+  end
 end

--- a/lib/api_checker/task_runner.ex
+++ b/lib/api_checker/task_runner.ex
@@ -136,7 +136,6 @@ defmodule ApiChecker.TaskRunner do
   end
 
   defp log_check_result({:error, reason}, check, params) do
-    reason_str = reason |> to_string() |> inspect()
-    "Check Failure - task_name=#{inspect(params.name)} check=#{inspect(check)} reason=#{reason_str}"
+    "Check Failure - task_name=#{inspect(params.name)} check=#{inspect(check)} reason=#{inspect(reason)}"
   end
 end

--- a/priv/dev_checks_config.json
+++ b/priv/dev_checks_config.json
@@ -52,7 +52,7 @@
         ],
         "checks": [
             { "type": "stale", "time_limit_in_seconds": 119 },
-            { "type": "json", "keypath": ["data"], "expects": "not_empty" }
+            { "type": "json", "keypath": ["data"], "expects": {"expectation": "min_length", "min_length": 15} }
         ]
     },
     {

--- a/test/api_checker/check/json_check_test.exs
+++ b/test/api_checker/check/json_check_test.exs
@@ -1,7 +1,7 @@
 defmodule ApiChecker.Check.JsonCheckTest do
   use ExUnit.Case, async: true
   alias ApiChecker.Check.{JsonCheck, Params}
-  alias JsonCheck.{Vehicle, Jsonapi, Array}
+  alias JsonCheck.{Jsonapi, Array}
   doctest JsonCheck
 
   describe "from_json/1" do

--- a/test/api_checker/check/json_check_test.exs
+++ b/test/api_checker/check/json_check_test.exs
@@ -41,5 +41,21 @@ defmodule ApiChecker.Check.JsonCheckTest do
       assert {:error, _} = JsonCheck.run_check(json_check, invalid_params1)
       assert {:error, _} = JsonCheck.run_check(json_check, invalid_params2)
     end
+
+    test "can handle expectations which are objects" do
+      valid_json = %{
+        "expects" => %{
+          "expectation" => "min_length",
+          "min_length" => 2
+        }
+      }
+
+      assert {:ok, json_check} = JsonCheck.from_json(valid_json)
+
+      valid_params = %Params{decoded_body: [1, 2]}
+      invalid_params = %Params{decoded_body: [1]}
+      assert {:ok, length: 2} = JsonCheck.run_check(json_check, valid_params)
+      assert {:error, _} = JsonCheck.run_check(json_check, invalid_params)
+    end
   end
 end

--- a/test/api_checker/periodic_task_test.exs
+++ b/test/api_checker/periodic_task_test.exs
@@ -56,7 +56,7 @@ defmodule ApiChecker.PeriodicTaskTest do
     url: "https://api-v3.mbta.com/predictions?filter%5Broute%5D=Red,Orange,Blue",
     frequency_in_seconds: 120,
     checks: [
-      %JsonCheck{keypath: ["data"], expects: ["array", "not_empty"]},
+      %JsonCheck{keypath: ["data"], expects: "not_empty"},
       %JsonCheck{keypath: ["jsonapi"], expects: "jsonapi"}
     ],
     time_ranges: [

--- a/test/api_checker/task_runner_test.exs
+++ b/test/api_checker/task_runner_test.exs
@@ -41,7 +41,7 @@ defmodule ApiChecker.TaskRunnerTest do
       assert captured =~ ~s(Check Failure)
       assert captured =~ ~s(task_name="failure-task")
       assert captured =~ ~s(%ApiChecker.Check.JsonCheck{expects: "not_empty", keypath: ["unexpected"]})
-      assert captured =~ ~s(reason="invalid_array")
+      assert captured =~ ~s(reason=:invalid_array)
     end
 
     @tag :capture_log

--- a/test/api_checker_test.exs
+++ b/test/api_checker_test.exs
@@ -11,7 +11,7 @@ defmodule ApiCheckerTest do
     url: "https://api-v3.mbta.com/predictions?filter%5Broute%5D=Red,Orange,Blue",
     frequency_in_seconds: 120,
     checks: [
-      %JsonCheck{keypath: ["data"], expects: ["array", "not_empty"]}
+      %JsonCheck{keypath: ["data"], expects: "not_empty"}
     ],
     time_ranges: [
       %WeeklyTimeRange{day: "MON", start: ~T[06:30:00], stop: ~T[22:00:00]},
@@ -27,7 +27,7 @@ defmodule ApiCheckerTest do
     url: "http://realtime.mbta.com/developer/api/v2/vehiclesbyroutes?format=json&routes=1",
     frequency_in_seconds: 120,
     checks: [
-      %JsonCheck{keypath: ["data"], expects: ["array", "not_empty"]}
+      %JsonCheck{keypath: ["data"], expects: "not_empty"}
     ],
     time_ranges: [
       %WeeklyTimeRange{day: "SAT", start: ~T[06:30:00], stop: ~T[22:00:00]}
@@ -39,7 +39,7 @@ defmodule ApiCheckerTest do
     url: "http://realtime.mbta.com/developer/api/v2/vehicles",
     frequency_in_seconds: 120,
     checks: [
-      %JsonCheck{keypath: ["data"], expects: ["array", "not_empty"]}
+      %JsonCheck{keypath: ["data"], expects: "not_empty"}
     ],
     time_ranges: [
       %WeeklyTimeRange{day: "THU", start: ~T[06:30:00], stop: ~T[22:00:00]}


### PR DESCRIPTION
After looking at the logs for the last week, I've come up with these minimums:

- subway predictions: 175
- bus predictions: 350
- CR predictions: 15
- CR boarding statuses: 12

They're 75% of whatever the lowest value I saw during our check hours was.